### PR TITLE
ci: update workflows using latest doc from github actions

### DIFF
--- a/.github/workflows/push_to_dockerhub.yml
+++ b/.github/workflows/push_to_dockerhub.yml
@@ -1,5 +1,5 @@
-# Article: https://medium.com/rockedscience/docker-ci-cd-pipeline-with-github-actions-6d4cd1731030
-name: Build and push Docker image when pushed to main
+# ref: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+name: Publish Docker Image
 
 on:
   push:
@@ -11,18 +11,28 @@ on:
 
 jobs:
   push_to_registry:
-    name: Build and push image to Docker Hub
+    name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: peter0083/mbta_tool
-          tag_with_ref: true # Info: https://github.com/docker/build-push-action/tree/releases/v1#tag_with_ref
-          tag_with_sha: true # Info: https://github.com/docker/build-push-action/tree/releases/v1#tag_with_sha
-          tags: latest
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: peter0083/mbta_tool
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The environment and dependencies of this repo are installed using Conda.
 To use this tool inside a container (recommended):
 - first, pull the image from Docker Hub
 ```commandline
-> docker pull peter0083/mbta_tool:dev
+> docker pull peter0083/mbta_tool
 ```
 - then, execute the following for a sample output
 ```commandline


### PR DESCRIPTION
- previous workflow seems outdated and does not push the image to docker hub